### PR TITLE
Adding goerli tokens for Testnet

### DIFF
--- a/boba.tokenlist.json
+++ b/boba.tokenlist.json
@@ -18,8 +18,24 @@
       "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/omg.png"
     },
     {
+      "chainId": 5,
+      "address": "0xCb9b561c91dDA1A9bAc33F7716a4d5586B7F5649",
+      "name": "OMGToken",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/omg.png"
+    },
+    {
       "chainId": 288,
       "address": "0xe1E2ec9a85C607092668789581251115bCBD20de",
+      "name": "OMGToken",
+      "symbol": "OMG",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/omg.png"
+    },
+    {
+      "chainId": 2888,
+      "address": "0x080bf38b43a1441873116002d36CCB583464cF45",
       "name": "OMGToken",
       "symbol": "OMG",
       "decimals": 18,
@@ -34,10 +50,34 @@
       "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/ethereum.svg"
     },
     {
+      "chainId": 5,
+      "address": "0x0000000000000000000000000000000000000000",
+      "name": "Ether",
+      "symbol": "ETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/ethereum.svg"
+    },
+    {
       "chainId": 288,
       "address": "0x4200000000000000000000000000000000000006",
       "name": "Ether",
       "symbol": "ETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/ethereum.svg"
+    },
+    {
+      "chainId": 288,
+      "address": "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+      "name": "Wrapped Ether",
+      "symbol": "wETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/ethereum.svg"
+    },
+    {
+      "chainId": 2888,
+      "address": "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+      "name": "Wrapped Ether",
+      "symbol": "wETH",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/ethereum.svg"
     },
@@ -82,8 +122,24 @@
       "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/usdc.png"
     },
     {
+      "chainId": 5,
+      "address": "0x07865c6e87b9f70255377e024ace6630c1eaa37f",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/usdc.png"
+    },
+    {
       "chainId": 288,
       "address": "0x66a2A913e447d6b4BF33EFbec43aAeF87890FBbc",
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "decimals": 6,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/usdc.png"
+    },
+    {
+      "chainId": 2888,
+      "address": "0x429582bDe1B0E011C48d883354050938f194743F",
       "name": "USD Coin",
       "symbol": "USDC",
       "decimals": 6,
@@ -258,8 +314,24 @@
       "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/boba-token.svg"
     },
     {
+      "chainId": 5,
+      "address": "0xeCCD355862591CBB4bB7E7dD55072070ee3d0fC1",
+      "name": "Boba Token",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/boba-token.svg"
+    },
+    {
       "chainId": 288,
       "address": "0xa18bF3994C0Cc6E3b63ac420308E5383f53120D7",
+      "name": "Boba Token",
+      "symbol": "BOBA",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/boba-token.svg"
+    },
+    {
+      "chainId": 2888,
+      "address": "0x4200000000000000000000000000000000000023",
       "name": "Boba Token",
       "symbol": "BOBA",
       "decimals": 18,

--- a/boba.tokenlist.json
+++ b/boba.tokenlist.json
@@ -66,6 +66,14 @@
       "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/ethereum.svg"
     },
     {
+      "chainId": 2888,
+      "address": "0x4200000000000000000000000000000000000006",
+      "name": "Ether",
+      "symbol": "ETH",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/bobanetwork/token-list/main/assets/ethereum.svg"
+    },
+    {
       "chainId": 288,
       "address": "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
       "name": "Wrapped Ether",


### PR DESCRIPTION
This PR includes the following list of tokens for Goearli Network: 

- BOBA NETWORK
- ETH
- WETH
- OMG
- USDC